### PR TITLE
add project/plugins.sbt, fixes compilation after a fresh clone

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.1")


### PR DESCRIPTION
`sbt compile` fails after a fresh clone of the repository. Adding a `project/plugins.sbt` file with the following contents resolved my issue:

```
addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.1")
```
